### PR TITLE
add `harmony_search` without multiprocessing

### DIFF
--- a/pyharmonysearch/harmony_search.py
+++ b/pyharmonysearch/harmony_search.py
@@ -73,6 +73,33 @@ def harmony_search(objective_function, num_processes, num_iterations, initial_ha
         pool.terminate()
 
 
+def harmony_search_serial(objective_function, num_iterations, initial_harmonies=None):
+    """
+        Same as ``harmony_search`` but without multiprocessing. This could be useful when there's already multiprocessing in, e.g.,
+        ``get_fitness`` method in ``objective_function``, since multiprocessing cannot be used within multiprocessing.
+    """
+    start = datetime.now()
+    results = [worker(objective_function, initial_harmonies) for i in range(num_iterations)]
+    end = datetime.now()
+    elapsed_time = end - start
+
+    # find best harmony from all iterations
+    best_harmony = None
+    best_fitness = float('-inf') if objective_function.maximize() else float('+inf')
+    harmony_memories = list()
+    harmony_histories = list()
+    for result in results:
+        harmony, fitness, harmony_memory, harmony_history = result
+        if (objective_function.maximize() and fitness > best_fitness) or (not objective_function.maximize() and fitness < best_fitness):
+            best_harmony = harmony
+            best_fitness = fitness
+        harmony_memories.append(harmony_memory)
+        harmony_histories.append(harmony_history)
+
+    return HarmonySearchResults(elapsed_time=elapsed_time, best_harmony=best_harmony, best_fitness=best_fitness,\
+                                harmony_memories=harmony_memories, harmony_histories=harmony_histories)
+
+
 def worker(objective_function, initial_harmonies=None):
     """
         This is just a dummy function to make multiprocessing work with a class. It also checks/sets the global multiprocessing.Event to prevent


### PR DESCRIPTION
This is usefuly when `objective_function.get_fitness()` already adopts
multiprocessing, since multiprocessing cannot be used within
multiprocessing.